### PR TITLE
Separate the "joinString" content from the concatenated files by line breaks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ class MarkDownConcatenator {
       ignore = [],
       decreaseTitleLevels = false,
       startTitleLevelAt = 1,
-      joinString = "\n",
+      joinString,
       titleKey,
       dirNameAsTitle = false,
       fileNameAsTitle = false,
@@ -121,7 +121,7 @@ class MarkDownConcatenator {
     this.ignore = ignore;
     this.decreaseTitleLevels = decreaseTitleLevels;
     this.startTitleLevelAt = startTitleLevelAt;
-    this.joinString = joinString;
+    this.joinString = joinString ? `\n${joinString}\n` : "\n";
     this.titleKey = titleKey;
     this.dirNameAsTitle = dirNameAsTitle;
     this.fileNameAsTitle = fileNameAsTitle;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,6 +51,14 @@ describe("concat", () => {
     expect(result).toBe(expected);
   });
 
+  it("should join concatenated files using a specified string.", async () => {
+    const result = await concat(join(__dirname, "test-helper/main"), {
+      joinString: "---",
+    });
+    const expected = await getExpected("join-separator.txt");
+    expect(result).toBe(expected);
+  });
+
   it("should add toc tag and table of contents.", async () => {
     const result = await concat(join(__dirname, "test-helper/main"), { toc: true });
     const expected = await getExpected("toc-tag.txt");

--- a/test/test-helper/expected/join-separator.txt
+++ b/test/test-helper/expected/join-separator.txt
@@ -1,0 +1,22 @@
+
+<a name="dir-aamd"></a>
+
+# Doc A
+
+---
+
+<a name="dir-bb1md"></a>
+
+# Doc B1
+
+---
+
+<a name="dir-bb2md"></a>
+
+# Doc B2
+
+---
+
+<a name="dir-bdir-b-subdir-b-sub-subb-submd"></a>
+
+# Doc BSub


### PR DESCRIPTION
The default value of `joinString` is a line break. If it is changed to something else, like to "---" (a full horizontal line), no line break will be appended. If the first concatenated file was not ended by a line break, the text "---" will be inserted at the end of the last line and will not be recognized as the markdown horizontal line. The leading line break is necessary to separate the `joinString` value from the first file. The trailing line break will separate the `joinString` value from the second file's content by an empty line.