### PR TITLE
Add "include" option to specify patterns to look for in the input directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ concat-md --toc --decrease-title-levels --file-name-as-title --dir-name-as-tit
 
 # Features
 
-- Scans all markdown files in a directory,
+- Scans all or specified markdown files in a directory,
 - Optionally ignores some files,
 - Concatenates all of them,
 - Adds table of contents,
@@ -54,6 +54,8 @@ Usage
 
 Options
   --ignore <globs csv>              - Glob patterns to exclude in 'dir'.
+  --include <globs csv>             - Glob patterns to look for in 'dir'.
+                                      Default: "**/*.md"
   --toc                             - Adds table of the contents at the beginning of file.
   --decrease-title-levels           - Whether to decrease levels of all titles in markdown file to set them below file and directory title levels.
   --start-title-level-at <level no> - Level to start file and directory levels. Default: 1
@@ -244,6 +246,7 @@ Concat function options.
 - [dirNameAsTitle](#optional-dirnameastitle)
 - [fileNameAsTitle](#optional-filenameastitle)
 - [ignore](#optional-ignore)
+- [include](#optional-include)
 - [joinString](#optional-joinstring)
 - [startTitleLevelAt](#optional-starttitlelevelat)
 - [titleKey](#optional-titlekey)
@@ -289,6 +292,16 @@ Whether to use file names as titles.
 _Defined in [index.ts:48](https://github.com/ozum/concat-md/blob/670ea75/src/index.ts#L48)_
 
 Glob patterns to exclude in `dir`.
+
+---
+
+#### `Optional` include
+
+• **include**? : _string | string[]_
+
+_Defined in [index.ts:48](https://github.com/ozum/concat-md/blob/670ea75/src/index.ts#L49)_
+
+Glob patterns to look for in `dir`. Default: "**/*.md"
 
 ---
 

--- a/src/bin/concat-md.ts
+++ b/src/bin/concat-md.ts
@@ -13,6 +13,7 @@ const lstat = fs.promises.lstat;
 interface Result extends meow.Result {
   flags: {
     ignore: string;
+    include: string;
     toc: boolean;
     tocLevel: string;
     decreaseTitleLevels: boolean;
@@ -29,6 +30,7 @@ interface Result extends meow.Result {
 /** @ignore */
 const FLAGS: meowOptions["flags"] = {
   ignore: { type: "string" },
+  include: { type: "string" },
   toc: { type: "boolean" },
   tocLevel: { type: "string" },
   decreaseTitleLevels: { type: "boolean" },
@@ -47,7 +49,8 @@ Usage
 
 Options
   --ignore <globs csv>              - Glob patterns to exclude in 'dir'.
-  --toc                             - Adds table of the contents at the beginning of file.
+  --include <globs csv>             - Glob patterns to look for in 'dir'. Default: "**/*.md"
+  --toc                             - Adds table of the contents at the beginning of file. Default: "**/*.md"
   --toc-level                       - Limit TOC entries to headings only up to the specified level. Default: 3
   --decrease-title-levels           - Whether to decrease levels of all titles in markdown file to set them below file and directory title levels.
   --start-title-level-at <level no> - Level to start file and directory levels. Default: 1
@@ -69,14 +72,25 @@ Examples
 `;
 
 /**
- * Splites CSV string of paths from CLI into array of absolute paths.
+ * Splits CSV string from CLI into array of strings.
  *
- * @param pathsCSV is comma split values of paths to split.
+ * @param valuesCSV is comma-split values to split.
+ * @returns array of string values.
+ * @ignore
+ */
+function splitStrings(valuesCSV: string): string[] {
+  return valuesCSV ? valuesCSV.split(/\s*,\s*/) : [];
+}
+
+/**
+ * Splits CSV string of paths from CLI into array of absolute paths.
+ *
+ * @param pathsCSV is comma-split values of paths to split.
  * @returns array of absolute paths converted from relative to cwd().
  * @ignore
  */
 function splitPaths(pathsCSV: string): string[] {
-  return pathsCSV ? pathsCSV.split(/\s*,\s*/).map(f => resolve(f)) : [];
+  return splitStrings(pathsCSV).map(f => resolve(f));
 }
 
 /** @ignore */
@@ -92,6 +106,7 @@ async function exec(): Promise<void> {
   const flags = {
     ...cli.flags,
     ignore: splitPaths(cli.flags.ignore),
+    include: splitStrings(cli.flags.include),
   };
 
   try {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,9 +13,17 @@ describe("concat", () => {
     expect(result).toBe(expected);
   });
 
-  it("should syncronously concat files as is.", async () => {
+  it("should synchronously concat files as is.", async () => {
     const result = concatMdSync(join(__dirname, "test-helper/main"));
     const expected = await getExpected("main-as-is.txt");
+    expect(result).toBe(expected);
+  });
+
+  it("should concat specified files only.", async () => {
+    const result = await concat(join(__dirname, "test-helper/main"), {
+      include: "dir-a/**/*.md",
+    });
+    const expected = await getExpected("main-specified-only.txt");
     expect(result).toBe(expected);
   });
 

--- a/test/test-helper/expected/main-specified-only.txt
+++ b/test/test-helper/expected/main-specified-only.txt
@@ -1,0 +1,4 @@
+
+<a name="dir-aamd"></a>
+
+# Doc A


### PR DESCRIPTION
If the markdown files are in multiple directories and the common parent directory contains lots of other files and directories, sometimes it is easier to specify what files and directories to include than what patterns to exclude. For example:

```txt
dist/
docs/
src/
node_modules/
README.md
```

And how to build a single PDF from the documentation:

`concat-md --include README,docs . | md-to-pdf > docs.pdf`