### PR TITLE
Pass globs unresolved by `path.resolve`

### DIFF
--- a/src/bin/concat-md.ts
+++ b/src/bin/concat-md.ts
@@ -76,7 +76,7 @@ Examples
  * @ignore
  */
 function splitPaths(pathsCSV: string): string[] {
-  return pathsCSV ? pathsCSV.split(/\s*,\s*/).map((f) => resolve(f)) : [];
+  return pathsCSV ? pathsCSV.split(/\s*,\s*/) : [];
 }
 
 /** @ignore */


### PR DESCRIPTION
Node builtin library `path` method `resolve` was mangling globs, resolving them to absolute references that globby refuses to match in the current working dir. This allows globs CSV from the command line to make it all the way to globby in a usable form.