### PR TITLE
feat: ConcatOptions sorter for sorting markdown paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Concat function options.
 - [hideAnchorLinks](#optional-hideanchorlinks)
 - [ignore](#optional-ignore)
 - [joinString](#optional-joinstring)
+- [sorter](#optional-sorter)
 - [startTitleLevelAt](#optional-starttitlelevelat)
 - [titleKey](#optional-titlekey)
 - [toc](#optional-toc)
@@ -313,6 +314,16 @@ _Defined in [index.ts:60](https://github.com/ozum/concat-md/blob/670ea75/src/ind
 String to be used to join concatenated files.
 
 ---
+
+### `Optional` sorter
+
+• **sorter**? : *undefined | (a: string, b: string) => number*
+
+*Defined in [index.ts:56](https://github.com/ozum/concat-md/blob/3cf72b4/src/index.ts#L82)*
+
+Custom sort function. If not set, files are sorted alphabetically.
+
+___
 
 #### `Optional` startTitleLevelAt
 

--- a/docs/interfaces/concatoptions.md
+++ b/docs/interfaces/concatoptions.md
@@ -19,6 +19,7 @@ Concat function options.
 * [fileNameAsTitle](concatoptions.md#optional-filenameastitle)
 * [ignore](concatoptions.md#optional-ignore)
 * [joinString](concatoptions.md#optional-joinstring)
+* [sorter](concatoptions.md#optional-sorter)
 * [startTitleLevelAt](concatoptions.md#optional-starttitlelevelat)
 * [titleKey](concatoptions.md#optional-titlekey)
 * [toc](concatoptions.md#optional-toc)
@@ -73,6 +74,16 @@ ___
 *Defined in [index.ts:60](https://github.com/ozum/concat-md/blob/3cf72b4/src/index.ts#L60)*
 
 String to be used to join concatenated files.
+
+___
+
+### `Optional` sorter
+
+• **sorter**? : *undefined | (a: string, b: string) => number*
+
+*Defined in [index.ts:56](https://github.com/ozum/concat-md/blob/3cf72b4/src/index.ts#L82)*
+
+Custom sort function. If not set, files are sorted alphabetically.
 
 ___
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,10 @@ export interface ConcatOptions {
    * Do not add anchor links
    */
   hideAnchorLinks?: boolean;
+  /**
+   * Custom sort function. If not set, files are sorted alphabetically.
+   */
+  sorter?: (a: string, b: string) => number;
 }
 
 /**
@@ -105,6 +109,7 @@ class MarkDownConcatenator {
   private fileTitleIndex: Map<string, { title: string; level: number; md: string }> = new Map();
   private tocLevel: number;
   private files: File[] = [];
+  private sorter: ConcatOptions["sorter"];
 
   public constructor(
     dir: string,
@@ -119,6 +124,7 @@ class MarkDownConcatenator {
       dirNameAsTitle = false,
       fileNameAsTitle = false,
       hideAnchorLinks = false,
+      sorter = undefined,
     }: ConcatOptions = {} as any
   ) {
     this.dir = dir;
@@ -132,6 +138,7 @@ class MarkDownConcatenator {
     this.dirNameAsTitle = dirNameAsTitle;
     this.fileNameAsTitle = fileNameAsTitle;
     this.hideAnchorLinks = hideAnchorLinks;
+    this.sorter = sorter;
   }
 
   private decreaseTitleLevelsBy(body: string, level: number): string {
@@ -140,12 +147,12 @@ class MarkDownConcatenator {
 
   private async getFileNames(): Promise<string[]> {
     const paths = await globby([`**/*.md`], { cwd: this.dir, ignore: arrify(this.ignore) });
-    return paths.sort().map((path) => join(this.dir, path));
+    return paths.sort(this.sorter).map((path) => join(this.dir, path));
   }
 
   private getFileNamesSync(): string[] {
     const paths = globby.sync([`**/*.md`], { cwd: this.dir, ignore: arrify(this.ignore) });
-    return paths.sort().map((path) => join(this.dir, path));
+    return paths.sort(this.sorter).map((path) => join(this.dir, path));
   }
 
   private async getFileDetails(): Promise<File[]> {


### PR DESCRIPTION
This allow pass sort function to use custom output order